### PR TITLE
Upgrading vulnerable dependencies

### DIFF
--- a/test-app/cypress/e2e/create.cy.ts
+++ b/test-app/cypress/e2e/create.cy.ts
@@ -15,7 +15,7 @@ describe('My Next.js App', () => {
 
     it('renders the form', () => {
         cy.contains("Create Device").should("be.visible");
-        cy.get('form').should('exist');
+        cy.get('Form').should('exist');
         cy.url().should('contain', '/create');
     })
 

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -30,7 +30,7 @@
         "@types/react": "18.0.28",
         "@types/react-dom": "18.0.11",
         "@types/testing-library__jest-dom": "^5.14.5",
-        "cypress": "^12.9.0",
+        "cypress": "^13.6.6",
         "eslint": "8.36.0",
         "eslint-config-next": "13.2.4",
         "identity-obj-proxy": "^3.0.0",
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -741,7 +741,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.10.4",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
@@ -3900,21 +3900,20 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cypress": {
-      "version": "12.17.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
-      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.6.tgz",
+      "integrity": "sha512-S+2S9S94611hXimH9a3EAYt81QM913ZVA03pUmGDfLTFa5gyp85NJ8dJGSlEAEmyRsYkioS1TtnWtbv/Fzt11A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "2.88.12",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
-        "buffer": "^5.6.0",
+        "buffer": "^5.7.1",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -3932,7 +3931,7 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^3.0.0",
+        "is-ci": "^3.0.1",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
@@ -3954,14 +3953,8 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
-    },
-    "node_modules/cypress/node_modules/@types/node": {
-      "version": "16.18.86",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.86.tgz",
-      "integrity": "sha512-QMvdZf+ZTSiv7gspwhqbfB7Y5DmbYgCsUnakS8Ul9uRbJQehDKaM7SL+GbcDS003Lh7VK4YlelHsRm9HCv26eA==",
-      "dev": true
     },
     "node_modules/cypress/node_modules/chalk": {
       "version": "4.1.2",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -38,7 +38,7 @@
     "@types/react": "18.0.28",
     "@types/react-dom": "18.0.11",
     "@types/testing-library__jest-dom": "^5.14.5",
-    "cypress": "^12.9.0",
+    "cypress": "^13.6.6",
     "eslint": "8.36.0",
     "eslint-config-next": "13.2.4",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
## Description
Upgrading Cypress to the latest version to mitigate a known Server-Side Request Forgery (SSRF) vulnerability. The vulnerability affects versions of Cypress <= 2.88.12.

## Vulnerability Details
The SSRF vulnerability in question allows attackers to send crafted requests from the server, potentially leading to unauthorised actions or access to sensitive information within our internal network. For more details on the vulnerability, please see the GitHub security advisory: https://github.com/advisories/GHSA-p8p7-x288-28g6.

## Testing
All unit and e2e tests pass, and manual validation confirms that test and development workflows remain unaffected.